### PR TITLE
Mvp/thumbnail

### DIFF
--- a/app/components/event/EventUploadedPictureList.client.vue
+++ b/app/components/event/EventUploadedPictureList.client.vue
@@ -66,7 +66,7 @@ async function handleDelete() {
             type="button" @click="toggleSelection(picture.deleteId)"
           >
             <img
-              :src="picture.url" alt=""
+              :src="picture.thumbnailUrl" alt=""
               class="w-full h-full object-cover transition-all duration-200 relative" :class="{
                 'ring-4 ring-merino-400 ring-opacity-70 z-10': selectedPictures.has(picture.deleteId),
                 'group-hover:opacity-90': !selectedPictures.has(picture.deleteId),

--- a/app/components/event/picture/EventPictureThumbnail.client.vue
+++ b/app/components/event/picture/EventPictureThumbnail.client.vue
@@ -73,7 +73,7 @@ function handleTouchEnd() {
   <div class="relative overflow-hidden select-none">
     <button class="appearance-none border-0 rounded-none bg-none w-full h-full block" @touchstart="handleTouchStart" @click="handleTouchEnd" @mousedown="handleTouchStart" @contextmenu.prevent>
       <img
-        ref="imageRef" :src="picture.url" class="w-full aspect-square object-cover pointer-events-none" :class="[
+        ref="imageRef" :src="picture.thumbnailUrl" class="w-full aspect-square object-cover pointer-events-none" :class="[
           isLoaded ? 'scale-100 opacity-100' : 'scale-105 opacity-0',
           shouldAnimate ? 'transition-all duration-700' : '',
         ]" :data-loaded="isLoaded" @load="handleImageLoad"

--- a/app/components/event/picture/insta-view/EventPictureInstaViewThumbnail.client.vue
+++ b/app/components/event/picture/insta-view/EventPictureInstaViewThumbnail.client.vue
@@ -71,7 +71,7 @@ function triggerHeartAnimation() {
       <div v-if="allowDoubleTap && showHeartAnimation" class="absolute z-10 inset-0 w-full h-full flex items-center justify-center pointer-events-none">
         <svg class="size-[20svh] stroke-1 stroke-almond-300 text-almond-300 animate-heart-like" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><!-- Icon from Google Material Icons by Material Design Authors - https://github.com/material-icons/material-icons/blob/master/LICENSE --><path fill="currentColor" d="m12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5C2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3C19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54z" /></svg>
       </div>
-      <img :src="picture.url" alt="" class="w-full h-auto object-contain max-h-[60svh] bg-almond-500/5" @click="allowDoubleTap ? onImageClick() : undefined">
+      <img :src="picture.thumbnailUrl" alt="" class="w-full h-auto object-contain max-h-[60svh] bg-almond-500/5" @click="allowDoubleTap ? onImageClick() : undefined">
     </div>
     <div class="flex gap-2 px-2 items-baseline mt-1">
       <button class="group transition-transform active:scale-95" :aria-pressed="isInFavorite(picture.id)" type="button" @click="toggleFavorite(picture.id)">

--- a/app/composables/useUploadedPictureStorage.ts
+++ b/app/composables/useUploadedPictureStorage.ts
@@ -3,6 +3,7 @@ import { useStorage } from '@vueuse/core'
 export interface UploadedPicture {
   id: string
   url: string
+  thumbnailUrl: string
   deleteId: string
 }
 

--- a/app/services/FileProcessorService.ts
+++ b/app/services/FileProcessorService.ts
@@ -65,4 +65,19 @@ export class FileProcessorService {
   static async processFiles(files: ClientFile[]): Promise<FileProcessingResult[]> {
     return Promise.all(files.map(file => this.processFile(file)))
   }
+
+  static async generateThumbnail(file: Uint8Array<ArrayBuffer>): Promise<Blob> {
+    const reduce = await import('picsquish')
+
+    const fileAsBlob = new Blob([file])
+
+    const squished = await reduce.squish(fileAsBlob, Math.min(THUMBNAIL_PROPERTY.WIDTH, THUMBNAIL_PROPERTY.HEIGHT), {
+      unsharpAmount: 160,
+      unsharpThreshold: 1,
+      unsharpRadius: 0.6,
+      filter: 'lanczos3',
+    })
+
+    return await squished.toBlob({ type: 'image/jpeg', quality: THUMBNAIL_PROPERTY.QUALITY })
+  }
 }

--- a/app/services/UploadStrategyService.ts
+++ b/app/services/UploadStrategyService.ts
@@ -1,3 +1,4 @@
+import type { InquirePayload } from '~~/server/api/events/single/[id]/inquire-upload.post'
 import type { EventBucketType } from '~~/server/database/schema/event-schema'
 import type { FileProcessingResult } from './FileProcessorService'
 
@@ -48,16 +49,12 @@ export class R2UploadStrategy implements ClientUploadStrategy {
 
     // Step 3: Confirm uploads with the server
     const mergedFileInformations = inquiryUploadUrls
-      .filter((info: any) => !info.isDuplicate)
-      .map((info: any) => {
+      .filter(info => !info.isDuplicate)
+      .map((info) => {
         const originalIndex = inquiryUploadUrls.indexOf(info)
         return {
           extension: batch[originalIndex]?.file.name.split('.').pop() || '',
-          contentType: info.payload.contentType,
-          length: info.payload.length,
-          id: info.payload.id,
-          filename: info.payload.filename,
-          hash: info.payload.hash,
+          ...info.payload,
           capturedAt: batch[originalIndex]?.capturedAt,
         }
       })
@@ -70,7 +67,7 @@ export class R2UploadStrategy implements ClientUploadStrategy {
     }) as UploadResult[]
   }
 
-  private async uploadToR2(batch: FileProcessingResult[], inquiryUploadUrls: any[]) {
+  private async uploadToR2(batch: FileProcessingResult[], inquiryUploadUrls: InquirePayload[]) {
     for (let i = 0; i < batch.length; i++) {
       const file = batch[i]?.file
       const uploadData = inquiryUploadUrls[i]

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "nuxt-toast": "^1.1.4",
         "pg": "^8.16.3",
         "qr-creator": "^1.0.0",
+        "sharp": "^0.34.3",
         "tailwindcss": "^4.1.11",
         "vue": "^3.5.17",
         "vue-router": "^4.5.1",
@@ -3086,6 +3087,424 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.3.tgz",
+      "integrity": "sha512-ryFMfvxxpQRsgZJqBd4wsttYQbCxsJksrv9Lw/v798JcQ8+w84mBWuXwl+TT0WJ/WrYOLaYpwQXi3sA9nTIaIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.0"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.3.tgz",
+      "integrity": "sha512-yHpJYynROAj12TA6qil58hmPmAwxKKC7reUqtGLzsOHfP7/rniNGTL8tjWX6L3CTV4+5P4ypcS7Pp+7OB+8ihA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.0"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.0.tgz",
+      "integrity": "sha512-sBZmpwmxqwlqG9ueWFXtockhsxefaV6O84BMOrhtg/YqbTaRdqDE7hxraVE3y6gVM4eExmfzW4a8el9ArLeEiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.0.tgz",
+      "integrity": "sha512-M64XVuL94OgiNHa5/m2YvEQI5q2cl9d/wk0qFTDVXcYzi43lxuiFTftMR1tOnFQovVXNZJ5TURSDK2pNe9Yzqg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.0.tgz",
+      "integrity": "sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.0.tgz",
+      "integrity": "sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.0.tgz",
+      "integrity": "sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.0.tgz",
+      "integrity": "sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.0.tgz",
+      "integrity": "sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.0.tgz",
+      "integrity": "sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.0.tgz",
+      "integrity": "sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.3.tgz",
+      "integrity": "sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.0"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.3.tgz",
+      "integrity": "sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.0"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.3.tgz",
+      "integrity": "sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.0"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.3.tgz",
+      "integrity": "sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.0"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.3.tgz",
+      "integrity": "sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.0"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.3.tgz",
+      "integrity": "sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.0"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.3.tgz",
+      "integrity": "sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.0"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.3.tgz",
+      "integrity": "sha512-+CyRcpagHMGteySaWos8IbnXcHgfDn7pO2fiC2slJxvNq9gDipYBN42/RagzctVRKgxATmfqOSulgZv5e1RdMg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.4.4"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.3.tgz",
+      "integrity": "sha512-MjnHPnbqMXNC2UgeLJtX4XqoVHHlZNd+nPt1kRPmj63wURegwBhZlApELdtxM2OIZDRv/DFtLcNhVbd1z8GYXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.3.tgz",
+      "integrity": "sha512-xuCdhH44WxuXgOM714hn4amodJMZl3OEvf0GVTm0BEyMeA2to+8HEdRPShH0SLYptJY1uBw+SCFP9WVQi1Q/cw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.3.tgz",
+      "integrity": "sha512-OWwz05d++TxzLEv4VnsTz5CmZ6mI6S05sfQGEMrNrQcOEERbX46332IvE7pO/EUiw7jUrrS40z/M7kPyjfl04g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@ioredis/commands": {
@@ -16674,6 +17093,82 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.3.tgz",
+      "integrity": "sha512-eX2IQ6nFohW4DbvHIOLRB3MHFpYqaqvXd3Tp5e/T/dSH83fxaNJQRvDMhASmkNTsNTVF2/OOopzRCt7xokgPfg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.4",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.3",
+        "@img/sharp-darwin-x64": "0.34.3",
+        "@img/sharp-libvips-darwin-arm64": "1.2.0",
+        "@img/sharp-libvips-darwin-x64": "1.2.0",
+        "@img/sharp-libvips-linux-arm": "1.2.0",
+        "@img/sharp-libvips-linux-arm64": "1.2.0",
+        "@img/sharp-libvips-linux-ppc64": "1.2.0",
+        "@img/sharp-libvips-linux-s390x": "1.2.0",
+        "@img/sharp-libvips-linux-x64": "1.2.0",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.0",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.0",
+        "@img/sharp-linux-arm": "0.34.3",
+        "@img/sharp-linux-arm64": "0.34.3",
+        "@img/sharp-linux-ppc64": "0.34.3",
+        "@img/sharp-linux-s390x": "0.34.3",
+        "@img/sharp-linux-x64": "0.34.3",
+        "@img/sharp-linuxmusl-arm64": "0.34.3",
+        "@img/sharp-linuxmusl-x64": "0.34.3",
+        "@img/sharp-wasm32": "0.34.3",
+        "@img/sharp-win32-arm64": "0.34.3",
+        "@img/sharp-win32-ia32": "0.34.3",
+        "@img/sharp-win32-x64": "0.34.3"
+      }
+    },
+    "node_modules/sharp/node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/sharp/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/sharp/node_modules/detect-libc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "nuxt-file-storage": "^0.3.0",
         "nuxt-toast": "^1.1.4",
         "pg": "^8.16.3",
+        "picsquish": "^0.3.0",
         "qr-creator": "^1.0.0",
         "sharp": "^0.34.3",
         "tailwindcss": "^4.1.11",
@@ -12165,6 +12166,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/glur": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/glur/-/glur-1.1.2.tgz",
+      "integrity": "sha512-l+8esYHTKOx2G/Aao4lEQ0bnHWg4fWtJbVoZZT9Knxi01pB8C80BR85nONLFwkkQoFRCmXY+BUcGZN3yZ2QsRA==",
+      "license": "MIT"
+    },
     "node_modules/gonzales-pe": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
@@ -15797,6 +15804,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/picsquish": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/picsquish/-/picsquish-0.3.0.tgz",
+      "integrity": "sha512-y+aDwako1SO26XRaa/+aE5wN/0xl4PlTycFMFqbqfO79YpRGs4TFlM2RuJSgSJRG9IAYQraUKhKMaTP7pbFCag==",
+      "license": "MIT",
+      "dependencies": {
+        "glur": "^1.1.2"
+      },
+      "peerDependencies": {
+        "typescript": "^5.7.2"
       }
     },
     "node_modules/pkg-types": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "nuxt-toast": "^1.1.4",
     "pg": "^8.16.3",
     "qr-creator": "^1.0.0",
+    "sharp": "^0.34.3",
     "tailwindcss": "^4.1.11",
     "vue": "^3.5.17",
     "vue-router": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "nuxt-file-storage": "^0.3.0",
     "nuxt-toast": "^1.1.4",
     "pg": "^8.16.3",
+    "picsquish": "^0.3.0",
     "qr-creator": "^1.0.0",
     "sharp": "^0.34.3",
     "tailwindcss": "^4.1.11",

--- a/server/api/events/single/[id]/inquire-upload.post.ts
+++ b/server/api/events/single/[id]/inquire-upload.post.ts
@@ -3,11 +3,14 @@ import { inArray } from 'drizzle-orm'
 import z from 'zod'
 import { useDrizzle } from '~~/server/database'
 import { getEventById } from '~~/server/service/EventService'
+import { buildUploadedPictureUrl } from '~~/server/service/ImageService'
 import { getPresignedUploadUrl } from '~~/server/service/R2Service'
 
 const eventIdRouterParam = z.object({
   id: z.uuid(),
 })
+
+export interface InquirePayload { url: string, isDuplicate: boolean, payload: { filename: string, filekey: string, id: string, contentType: string, length: number, hash: string }, headers: Record<string, string> }
 
 const fileInformationsSchema = z.array(z.object({
   hash: z.string().length(64), // SHA-256 hash of the file
@@ -45,12 +48,12 @@ export default defineEventHandler(async (event) => {
   }
 
   const db = useDrizzle()
-  const signedPayloads: { url: string, isDuplicate: boolean, payload: { filename: string, id: string, contentType: string, length: number, hash: string }, headers: Record<string, string> }[] = []
+  const signedPayloads: InquirePayload[] = []
 
-  const existingPictureHashes = await db.query.pictures.findMany({
-    where: (pictures, { eq, and }) => and(
-      eq(pictures.eventId, eventId),
-      inArray(pictures.pictureHash, fileInformations.map(fi => fi.hash)),
+  const existingPictureHashes = await db.query.medias.findMany({
+    where: (medias, { eq, and }) => and(
+      eq(medias.eventId, eventId),
+      inArray(medias.pictureHash, fileInformations.map(fi => fi.hash)),
     ),
     columns: {
       pictureHash: true,
@@ -65,6 +68,7 @@ export default defineEventHandler(async (event) => {
         url: '',
         payload: {
           filename: '',
+          filekey: '',
           id: '',
           contentType: fileInformation.contentType,
           length: fileInformation.length,
@@ -79,13 +83,15 @@ export default defineEventHandler(async (event) => {
     const pictureId = crypto.randomUUID()
 
     const filename = `${pictureId}.${fileInformation.extension}`
+    const filekey = buildUploadedPictureUrl(eventId, filename)
 
+    // Custom headers to store metadata in R2 object
     const customHeadersForMetadata = {
       'x-amz-meta-eventid': eventId,
       'x-amz-meta-guestid': session.user.id,
     }
 
-    const url = await getPresignedUploadUrl(filename, fileInformation.contentType, fileInformation.length, {
+    const url = await getPresignedUploadUrl(filekey, fileInformation.contentType, fileInformation.length, {
       eventId,
       guestId: session.user.id,
     }, customHeadersForMetadata)
@@ -94,6 +100,7 @@ export default defineEventHandler(async (event) => {
       url,
       payload: {
         filename,
+        filekey,
         id: pictureId,
         contentType: fileInformation.contentType,
         length: fileInformation.length,

--- a/server/api/events/single/[id]/pictures/batch.get.ts
+++ b/server/api/events/single/[id]/pictures/batch.get.ts
@@ -2,7 +2,7 @@ import { and, eq, inArray } from 'drizzle-orm'
 import z from 'zod'
 import { useDrizzle } from '~~/server/database'
 import { guests } from '~~/server/database/schema/guest-schema'
-import { pictures } from '~~/server/database/schema/picture-schema'
+import { medias } from '~~/server/database/schema/media-schema'
 import { getEventById } from '~~/server/service/EventService'
 
 const eventIdRouterParam = z.object({
@@ -38,19 +38,19 @@ export default defineEventHandler(async (event) => {
   // Get pictures by IDs that belong to the specified event with guest information
   const picturesList = await db
     .select({
-      id: pictures.id,
-      url: pictures.url,
-      capturedAt: pictures.capturedAt,
-      createdAt: pictures.createdAt,
-      guestId: pictures.guestId,
+      id: medias.id,
+      url: medias.url,
+      capturedAt: medias.capturedAt,
+      createdAt: medias.createdAt,
+      guestId: medias.guestId,
       guestNickname: guests.nickname,
     })
-    .from(pictures)
-    .leftJoin(guests, eq(pictures.guestId, guests.id))
+    .from(medias)
+    .leftJoin(guests, eq(medias.guestId, guests.id))
     .where(
       and(
-        eq(pictures.eventId, eventId),
-        inArray(pictures.id, pictureIds),
+        eq(medias.eventId, eventId),
+        inArray(medias.id, pictureIds),
       ),
     )
 

--- a/server/api/events/single/[id]/pictures/batch.get.ts
+++ b/server/api/events/single/[id]/pictures/batch.get.ts
@@ -44,6 +44,7 @@ export default defineEventHandler(async (event) => {
       createdAt: medias.createdAt,
       guestId: medias.guestId,
       guestNickname: guests.nickname,
+      thumbnailUrl: medias.thumbnailUrl,
     })
     .from(medias)
     .leftJoin(guests, eq(medias.guestId, guests.id))

--- a/server/api/events/single/[id]/pictures/index.get.ts
+++ b/server/api/events/single/[id]/pictures/index.get.ts
@@ -19,6 +19,7 @@ const querySchema = z.object({
 export interface UploadedPicture {
   id: string
   url: string
+  thumbnailUrl: string
   capturedAt: Date
   createdAt: Date
   guestId: string
@@ -62,6 +63,7 @@ export default defineEventHandler(async (event) => {
       createdAt: medias.createdAt,
       guestId: medias.guestId,
       guestNickname: guests.nickname,
+      thumbnailUrl: medias.thumbnailUrl,
     })
     .from(medias)
     .leftJoin(guests, eq(medias.guestId, guests.id))

--- a/server/api/events/single/[id]/pictures/index.get.ts
+++ b/server/api/events/single/[id]/pictures/index.get.ts
@@ -2,7 +2,7 @@ import { asc, desc, eq, sql } from 'drizzle-orm'
 import z from 'zod'
 import { useDrizzle } from '~~/server/database'
 import { guests } from '~~/server/database/schema/guest-schema'
-import { pictures } from '~~/server/database/schema/picture-schema'
+import { medias } from '~~/server/database/schema/media-schema'
 import { getEventById } from '~~/server/service/EventService'
 
 const eventIdRouterParam = z.object({
@@ -44,28 +44,28 @@ export default defineEventHandler(async (event) => {
   const offset = (query.page - 1) * query.limit
 
   // Determine sort column and order
-  const sortColumn = query.sortBy === 'capturedAt' ? pictures.capturedAt : pictures.createdAt
+  const sortColumn = query.sortBy === 'capturedAt' ? medias.capturedAt : medias.createdAt
   const sortOrder = query.sortOrder === 'asc' ? asc(sortColumn) : desc(sortColumn)
 
   // Get total count for pagination metadata
   const [totalCount] = await db
     .select({ count: sql<number>`count(*)` })
-    .from(pictures)
-    .where(eq(pictures.eventId, eventId))
+    .from(medias)
+    .where(eq(medias.eventId, eventId))
 
   // Get paginated pictures - ALL pictures for the event with guest information
   const picturesList: UploadedPicture[] = await db
     .select({
-      id: pictures.id,
-      url: pictures.url,
-      capturedAt: pictures.capturedAt,
-      createdAt: pictures.createdAt,
-      guestId: pictures.guestId,
+      id: medias.id,
+      url: medias.url,
+      capturedAt: medias.capturedAt,
+      createdAt: medias.createdAt,
+      guestId: medias.guestId,
       guestNickname: guests.nickname,
     })
-    .from(pictures)
-    .leftJoin(guests, eq(pictures.guestId, guests.id))
-    .where(eq(pictures.eventId, eventId))
+    .from(medias)
+    .leftJoin(guests, eq(medias.guestId, guests.id))
+    .where(eq(medias.eventId, eventId))
     .orderBy(sortOrder)
     .limit(query.limit)
     .offset(offset)

--- a/server/api/events/single/[id]/pictures/magic-delete.delete.ts
+++ b/server/api/events/single/[id]/pictures/magic-delete.delete.ts
@@ -1,7 +1,7 @@
 import { and, eq, inArray } from 'drizzle-orm'
 import z from 'zod'
 import { useDrizzle } from '~~/server/database'
-import { pictures } from '~~/server/database/schema/picture-schema'
+import { medias } from '~~/server/database/schema/media-schema'
 import { PictureDeletionOrchestrator } from '~~/server/service/deletion/PictureDeletionOrchestrator'
 import { getEventById } from '~~/server/service/EventService'
 
@@ -41,11 +41,11 @@ export default defineEventHandler(async (event) => {
     // Find pictures that match the magic delete IDs and belong to the current user and event
     const picturesToDelete = await db
       .select()
-      .from(pictures)
+      .from(medias)
       .where(
         and(
-          inArray(pictures.magicDeleteId, parsedRequest.magicDeleteIds),
-          eq(pictures.eventId, eventId),
+          inArray(medias.magicDeleteId, parsedRequest.magicDeleteIds),
+          eq(medias.eventId, eventId),
         ),
       )
 
@@ -59,17 +59,17 @@ export default defineEventHandler(async (event) => {
 
     // Delete the pictures from the database first
     const deletedPictures = await db
-      .delete(pictures)
+      .delete(medias)
       .where(
         and(
-          inArray(pictures.magicDeleteId, parsedRequest.magicDeleteIds),
-          eq(pictures.eventId, eventId),
+          inArray(medias.magicDeleteId, parsedRequest.magicDeleteIds),
+          eq(medias.eventId, eventId),
         ),
       )
       .returning({
-        url: pictures.url,
-        filename: pictures.filename,
-        magicDeleteId: pictures.magicDeleteId,
+        url: medias.url,
+        filename: medias.filename,
+        magicDeleteId: medias.magicDeleteId,
       })
 
     const deletionResult = await PictureDeletionOrchestrator.deletePictures(

--- a/server/api/events/single/[id]/upload.post.ts
+++ b/server/api/events/single/[id]/upload.post.ts
@@ -1,4 +1,5 @@
 import type { ServerFile } from 'nuxt-file-storage'
+import type { UploadResult } from '~/services/UploadStrategyService'
 import z from 'zod'
 import { getEventById } from '~~/server/service/EventService'
 import { PictureUploadOrchestrator } from '~~/server/service/upload/PictureUploadOrchestrator'
@@ -15,6 +16,7 @@ const fileInformationsSchema = z.array(z.union([
     id: z.uuid(),
     filename: z.string().max(64),
     filekey: z.string().max(256),
+    thumbnailFilekey: z.string().max(256),
     hash: z.string().length(64),
     capturedAt: z.coerce.date().optional(),
   }),
@@ -24,7 +26,7 @@ const fileInformationsSchema = z.array(z.union([
   }).strict(),
 ])).max(5)
 
-export default defineEventHandler(async (event) => {
+export default defineEventHandler<Promise<UploadResult[]>>(async (event) => {
   const { id: eventId } = await getValidatedRouterParams(event, eventIdRouterParam.parse)
   const { files, filesInformations } = await readBody<{ files: ServerFile[] | undefined, filesInformations: unknown }>(event)
   const session = await requireUserSession(event)
@@ -75,6 +77,7 @@ export default defineEventHandler(async (event) => {
       id: string
       filename: string
       filekey: string
+      thumbnailFilekey: string
       hash: string
       capturedAt?: Date
     } =>

--- a/server/api/events/single/[id]/upload.post.ts
+++ b/server/api/events/single/[id]/upload.post.ts
@@ -14,6 +14,7 @@ const fileInformationsSchema = z.array(z.union([
     length: z.number(),
     id: z.uuid(),
     filename: z.string().max(64),
+    filekey: z.string().max(256),
     hash: z.string().length(64),
     capturedAt: z.coerce.date().optional(),
   }),
@@ -73,6 +74,7 @@ export default defineEventHandler(async (event) => {
       length: number
       id: string
       filename: string
+      filekey: string
       hash: string
       capturedAt?: Date
     } =>

--- a/server/database/index.ts
+++ b/server/database/index.ts
@@ -2,7 +2,7 @@ import type { NodePgDatabase } from 'drizzle-orm/node-postgres'
 import { drizzle } from 'drizzle-orm/node-postgres'
 import { events, eventsRelations } from './schema/event-schema'
 import { guests, guestsRelations } from './schema/guest-schema'
-import { pictures, picturesRelations } from './schema/picture-schema'
+import { medias, mediasRelations } from './schema/media-schema'
 
 const config = useRuntimeConfig()
 
@@ -11,8 +11,8 @@ const schema = {
   eventsRelations,
   guests,
   guestsRelations,
-  pictures,
-  picturesRelations,
+  medias,
+  picturesRelations: mediasRelations,
 } as const
 
 type Schema = typeof schema

--- a/server/database/schema/event-schema.ts
+++ b/server/database/schema/event-schema.ts
@@ -1,7 +1,7 @@
 import { relations } from 'drizzle-orm'
 import { pgEnum, pgTable, text, timestamp, uuid, varchar } from 'drizzle-orm/pg-core'
 import { guests } from './guest-schema'
-import { pictures } from './picture-schema'
+import { medias } from './media-schema'
 
 export const eventState = pgEnum('event_state', ['draft', 'started', 'done'])
 export type EventState = typeof eventState.enumValues[number]
@@ -24,7 +24,7 @@ export const events = pgTable('events', {
 })
 
 export const eventsRelations = relations(events, ({ many }) => ({
-  pictures: many(pictures),
+  medias: many(medias),
   guests: many(guests),
 }))
 

--- a/server/database/schema/guest-schema.ts
+++ b/server/database/schema/guest-schema.ts
@@ -1,7 +1,7 @@
 import { relations } from 'drizzle-orm'
 import { pgTable, timestamp, uuid, varchar } from 'drizzle-orm/pg-core'
 import { events } from './event-schema'
-import { pictures } from './picture-schema'
+import { medias } from './media-schema'
 
 export const guests = pgTable('guests', {
   id: uuid('id').primaryKey().defaultRandom(),
@@ -12,5 +12,5 @@ export const guests = pgTable('guests', {
 })
 
 export const guestsRelations = relations(guests, ({ many }) => ({
-  pictures: many(pictures),
+  medias: many(medias),
 }))

--- a/server/database/schema/media-schema.ts
+++ b/server/database/schema/media-schema.ts
@@ -4,9 +4,10 @@ import { bigint, pgTable, text, timestamp, uuid, varchar } from 'drizzle-orm/pg-
 import { events } from './event-schema'
 import { guests } from './guest-schema'
 
-export const pictures = pgTable('pictures', {
+export const medias = pgTable('medias', {
   id: uuid('id').primaryKey().defaultRandom(),
   url: text('url').notNull(),
+  thumbnailUrl: text('thumbnail_url').notNull(),
   filename: varchar('filename', { length: 64 }).notNull().unique(), // Technically could be 32 characters + extension length
   size: bigint('size', { mode: 'number' }).notNull(),
   capturedAt: timestamp('captured_at').defaultNow().notNull(),
@@ -15,19 +16,20 @@ export const pictures = pgTable('pictures', {
   guestId: uuid('guest_id').notNull().references(() => guests.id, { onDelete: 'cascade' }),
   eventId: uuid('event_id').notNull().references(() => events.id, { onDelete: 'cascade' }),
   pictureHash: varchar('picture_hash', { length: 64 }).notNull(),
+
   generatedUniquePictureHash: text('generated_unique_picture_hash')
-    .generatedAlwaysAs((): SQL => sql`${pictures.eventId} || ${pictures.pictureHash}`)
+    .generatedAlwaysAs((): SQL => sql`${medias.eventId} || ${medias.pictureHash}`)
     .unique(),
   magicDeleteId: uuid('magic_delete_id').defaultRandom().notNull(),
 })
 
-export const picturesRelations = relations(pictures, ({ one }) => ({
+export const mediasRelations = relations(medias, ({ one }) => ({
   owner: one(guests, {
-    fields: [pictures.guestId],
+    fields: [medias.guestId],
     references: [guests.id],
   }),
   event: one(events, {
-    fields: [pictures.eventId],
+    fields: [medias.eventId],
     references: [events.id],
   }),
 }))

--- a/server/service/EventService.ts
+++ b/server/service/EventService.ts
@@ -1,7 +1,7 @@
 import { count, eq } from 'drizzle-orm'
 import { useDrizzle } from '../database'
 import { events } from '../database/schema/event-schema'
-import { pictures } from '../database/schema/picture-schema'
+import { medias } from '../database/schema/media-schema'
 
 export async function getRawEventById(eventId: string) {
   return await useDrizzle().query.events.findFirst({
@@ -36,8 +36,8 @@ export async function getRawEventPictureCount(eventId: string) {
   const db = useDrizzle()
   const [result] = await db
     .select({ count: count() })
-    .from(pictures)
-    .where(eq(pictures.eventId, eventId))
+    .from(medias)
+    .where(eq(medias.eventId, eventId))
 
   return result.count
 }

--- a/server/service/ImageService.ts
+++ b/server/service/ImageService.ts
@@ -17,6 +17,14 @@ export function getUploadedPictureFolder(eventId: string) {
   return `public/events/${eventId}/pictures/`
 }
 
+export function getUploadedThumbnailFolder(eventId: string) {
+  return `public/events/${eventId}/thumbnails/`
+}
+
 export function buildUploadedPictureUrl(eventId: string, filename: string) {
   return `events/${eventId}/pictures/${filename}`
+}
+
+export function buildUploadedThumbnailUrl(eventId: string, filename: string) {
+  return `events/${eventId}/thumbnails/${filename}`
 }

--- a/server/service/ImageService.ts
+++ b/server/service/ImageService.ts
@@ -14,7 +14,7 @@ export function getCoverImageFolder(storageType: AvailableStorageType, eventId: 
 }
 
 export function getUploadedPictureFolder(eventId: string) {
-  return `public/events/${eventId}/pictures/`
+  return `public/events/${eventId}/medias/`
 }
 
 export function getUploadedThumbnailFolder(eventId: string) {
@@ -22,7 +22,7 @@ export function getUploadedThumbnailFolder(eventId: string) {
 }
 
 export function buildUploadedPictureUrl(eventId: string, filename: string) {
-  return `events/${eventId}/pictures/${filename}`
+  return `events/${eventId}/medias/${filename}`
 }
 
 export function buildUploadedThumbnailUrl(eventId: string, filename: string) {

--- a/server/service/upload/FilesystemUploadStrategy.ts
+++ b/server/service/upload/FilesystemUploadStrategy.ts
@@ -3,7 +3,7 @@ import type { events } from '~~/server/database/schema/event-schema'
 import type { ProcessedFileInfo, UploadResult, UploadStrategy } from './UploadStrategy'
 import crypto from 'node:crypto'
 import { useDrizzle } from '~~/server/database'
-import { pictures } from '~~/server/database/schema/picture-schema'
+import { medias } from '~~/server/database/schema/media-schema'
 import { buildUploadedPictureUrl, getUploadedPictureFolder } from '~~/server/service/ImageService'
 
 export class FilesystemUploadStrategy implements UploadStrategy {
@@ -23,7 +23,7 @@ export class FilesystemUploadStrategy implements UploadStrategy {
     }
 
     const db = useDrizzle()
-    const pictureRecords: Array<typeof pictures.$inferInsert> = []
+    const pictureRecords: Array<typeof medias.$inferInsert> = []
     const results: UploadResult[] = []
 
     for (const fileInfo of files) {
@@ -52,9 +52,10 @@ export class FilesystemUploadStrategy implements UploadStrategy {
           id: pictureId,
           guestId,
           url,
+          thumbnailUrl: url, // TODO  replace
           capturedAt: fileInfo.capturedAt,
           pictureHash: fileInfo.hash,
-          size: Number(fileInfo.file.size),
+          size: Number((fileInfo.file as ServerFile).size),
           magicDeleteId,
         })
 
@@ -75,7 +76,7 @@ export class FilesystemUploadStrategy implements UploadStrategy {
 
     // Batch insert all successfully processed pictures
     if (pictureRecords.length > 0) {
-      await db.insert(pictures).values(pictureRecords).onConflictDoNothing()
+      await db.insert(medias).values(pictureRecords).onConflictDoNothing()
     }
 
     return results

--- a/server/service/upload/PictureUploadOrchestrator.ts
+++ b/server/service/upload/PictureUploadOrchestrator.ts
@@ -62,6 +62,7 @@ export class PictureUploadOrchestrator {
       length: number
       id: string
       filename: string
+      filekey: string
       capturedAt?: Date
     }>,
   ): R2ProcessedFileInfo[] {
@@ -73,6 +74,8 @@ export class PictureUploadOrchestrator {
       capturedAt: info.capturedAt,
       id: info.id,
       filename: info.filename,
+      filekey: info.filekey,
+      file: info.filekey,
     }))
   }
 

--- a/server/service/upload/PictureUploadOrchestrator.ts
+++ b/server/service/upload/PictureUploadOrchestrator.ts
@@ -64,6 +64,7 @@ export class PictureUploadOrchestrator {
       filename: string
       filekey: string
       capturedAt?: Date
+      thumbnailFilekey: string
     }>,
   ): R2ProcessedFileInfo[] {
     return fileInformations.map(info => ({
@@ -76,6 +77,7 @@ export class PictureUploadOrchestrator {
       filename: info.filename,
       filekey: info.filekey,
       file: info.filekey,
+      thumbnailFilekey: info.thumbnailFilekey,
     }))
   }
 

--- a/server/service/upload/R2UploadStrategy.ts
+++ b/server/service/upload/R2UploadStrategy.ts
@@ -8,12 +8,12 @@ import { buildPublicUrl, retrieveFileMetadata } from '~~/server/service/R2Servic
 export class R2UploadStrategy implements UploadStrategy {
   requiresPresignedUrls = (): boolean => true
 
-  uploadFiles = async (
+  async uploadFiles(
     files: ProcessedFileInfo[],
     eventId: string,
     guestId: string,
     event: typeof events.$inferSelect,
-  ): Promise<UploadResult[]> => {
+  ): Promise<UploadResult[]> {
     if (event.bucketType !== 'R2') {
       throw createError({
         statusCode: 400,
@@ -59,12 +59,13 @@ export class R2UploadStrategy implements UploadStrategy {
           pictureHash: fileInfo.hash,
           size: uploadResult.actualSize,
           magicDeleteId,
-          thumbnailUrl: uploadResult.url, // Placeholder, replace with actual thumbnail URL if available
+          thumbnailUrl: uploadResult.thumbnailUrl,
         })
 
         results.push({
           id: pictureId,
           url: uploadResult.url,
+          thumbnailUrl: uploadResult.thumbnailUrl,
           deleteId: magicDeleteId,
         })
       }
@@ -97,9 +98,12 @@ export class R2UploadStrategy implements UploadStrategy {
       })
     }
 
-    const fileMetadata = await retrieveFileMetadata(fileInfo.filekey)
-    if (fileMetadata.Metadata && 'eventid' in fileMetadata.Metadata && 'guestid' in fileMetadata.Metadata) {
-      if (fileMetadata.Metadata.eventid !== eventId || fileMetadata.Metadata.guestid !== guestId) {
+    const [fileMetadata, thumbnailMetadata] = await Promise.all([retrieveFileMetadata(fileInfo.filekey), retrieveFileMetadata(fileInfo.thumbnailFilekey)])
+    if ((fileMetadata.Metadata && 'eventid' in fileMetadata.Metadata && 'guestid' in fileMetadata.Metadata)
+      && (thumbnailMetadata.Metadata && 'eventid' in thumbnailMetadata.Metadata && 'guestid' in thumbnailMetadata.Metadata)
+    ) {
+      if (fileMetadata.Metadata.eventid !== eventId || fileMetadata.Metadata.guestid !== guestId
+        || thumbnailMetadata.Metadata.eventid !== eventId || thumbnailMetadata.Metadata.guestid !== guestId) {
         throw createError({
           statusCode: 400,
           statusMessage: 'File metadata does not match event or guest',
@@ -108,13 +112,17 @@ export class R2UploadStrategy implements UploadStrategy {
             expectedGuestId: guestId,
             actualEventId: fileMetadata.Metadata.eventid,
             actualGuestId: fileMetadata.Metadata.guestid,
+            actualThumbnailEventId: thumbnailMetadata.Metadata.eventid,
+            actualThumbnailGuestId: thumbnailMetadata.Metadata.guestid,
           },
         })
       }
+
       return {
         success: true,
-        actualSize: Number(fileMetadata.ContentLength),
+        actualSize: Number((fileMetadata.ContentLength ?? 0) + (thumbnailMetadata.ContentLength ?? 0)),
         url: buildPublicUrl(fileInfo.filekey),
+        thumbnailUrl: buildPublicUrl(fileInfo.thumbnailFilekey),
       }
     }
     else {

--- a/server/service/upload/R2UploadStrategy.ts
+++ b/server/service/upload/R2UploadStrategy.ts
@@ -97,7 +97,7 @@ export class R2UploadStrategy implements UploadStrategy {
       })
     }
 
-    const fileMetadata = await retrieveFileMetadata(fileInfo.filename)
+    const fileMetadata = await retrieveFileMetadata(fileInfo.filekey)
     if (fileMetadata.Metadata && 'eventid' in fileMetadata.Metadata && 'guestid' in fileMetadata.Metadata) {
       if (fileMetadata.Metadata.eventid !== eventId || fileMetadata.Metadata.guestid !== guestId) {
         throw createError({
@@ -114,7 +114,7 @@ export class R2UploadStrategy implements UploadStrategy {
       return {
         success: true,
         actualSize: Number(fileMetadata.ContentLength),
-        url: buildPublicUrl(fileInfo.filename),
+        url: buildPublicUrl(fileInfo.filekey),
       }
     }
     else {

--- a/server/service/upload/R2UploadStrategy.ts
+++ b/server/service/upload/R2UploadStrategy.ts
@@ -2,7 +2,7 @@ import type { events } from '~~/server/database/schema/event-schema'
 import type { ProcessedFileInfo, R2ProcessedFileInfo, UploadResult, UploadStrategy } from './UploadStrategy'
 import crypto from 'node:crypto'
 import { useDrizzle } from '~~/server/database'
-import { pictures } from '~~/server/database/schema/picture-schema'
+import { medias } from '~~/server/database/schema/media-schema'
 import { buildPublicUrl, retrieveFileMetadata } from '~~/server/service/R2Service'
 
 export class R2UploadStrategy implements UploadStrategy {
@@ -22,7 +22,7 @@ export class R2UploadStrategy implements UploadStrategy {
     }
 
     const db = useDrizzle()
-    const pictureRecords: Array<typeof pictures.$inferInsert> = []
+    const pictureRecords: Array<typeof medias.$inferInsert> = []
     const results: UploadResult[] = []
 
     for (const fileInfo of files) {
@@ -59,6 +59,7 @@ export class R2UploadStrategy implements UploadStrategy {
           pictureHash: fileInfo.hash,
           size: uploadResult.actualSize,
           magicDeleteId,
+          thumbnailUrl: uploadResult.url, // Placeholder, replace with actual thumbnail URL if available
         })
 
         results.push({
@@ -78,7 +79,7 @@ export class R2UploadStrategy implements UploadStrategy {
 
     // Batch insert all successfully processed pictures
     if (pictureRecords.length > 0) {
-      await db.insert(pictures).values(pictureRecords).onConflictDoNothing()
+      await db.insert(medias).values(pictureRecords).onConflictDoNothing()
     }
 
     return results

--- a/server/service/upload/UploadStrategy.ts
+++ b/server/service/upload/UploadStrategy.ts
@@ -1,5 +1,5 @@
 import type { events } from '~~/server/database/schema/event-schema'
-import type { pictures } from '~~/server/database/schema/media-schema'
+import type { medias } from '~~/server/database/schema/media-schema'
 
 export interface ProcessedFileInfo {
   hash: string
@@ -13,6 +13,7 @@ export interface ProcessedFileInfo {
 export interface R2ProcessedFileInfo extends ProcessedFileInfo {
   id: string
   filename: string
+  filekey: string
 }
 
 export interface UploadResult {
@@ -32,7 +33,7 @@ export interface UploadStrategy {
   requiresPresignedUrls: () => boolean
 }
 
-export interface PictureRecord extends Omit<typeof pictures.$inferInsert, 'id'> {
+export interface PictureRecord extends Omit<typeof medias.$inferInsert, 'id'> {
   id: string
   deleteId: string
 }

--- a/server/service/upload/UploadStrategy.ts
+++ b/server/service/upload/UploadStrategy.ts
@@ -1,5 +1,5 @@
 import type { events } from '~~/server/database/schema/event-schema'
-import type { pictures } from '~~/server/database/schema/picture-schema'
+import type { pictures } from '~~/server/database/schema/media-schema'
 
 export interface ProcessedFileInfo {
   hash: string

--- a/server/service/upload/UploadStrategy.ts
+++ b/server/service/upload/UploadStrategy.ts
@@ -14,11 +14,13 @@ export interface R2ProcessedFileInfo extends ProcessedFileInfo {
   id: string
   filename: string
   filekey: string
+  thumbnailFilekey: string
 }
 
 export interface UploadResult {
   id: string
   url: string
+  thumbnailUrl: string
   deleteId: string
 }
 

--- a/shared/utils/constants.ts
+++ b/shared/utils/constants.ts
@@ -1,0 +1,5 @@
+export const THUMBNAIL_PROPERTY = {
+  WIDTH: 1200,
+  HEIGHT: 1200,
+  QUALITY: 80,
+} as const

--- a/shared/utils/constants.ts
+++ b/shared/utils/constants.ts
@@ -1,5 +1,5 @@
 export const THUMBNAIL_PROPERTY = {
-  WIDTH: 1200,
-  HEIGHT: 1200,
+  WIDTH: 600,
+  HEIGHT: 600,
   QUALITY: 80,
 } as const


### PR DESCRIPTION
## Summary by Sourcery

Add end-to-end thumbnail support for media uploads by generating previews, updating storage flows, schema, APIs, and UI.

New Features:
- Generate and store server‐side thumbnails for filesystem uploads using sharp
- Produce presigned URLs for thumbnail uploads and validate thumbnail metadata in the R2 flow
- Add client‐side thumbnail generation for R2 uploads using picsquish

Enhancements:
- Rename the pictures table to medias, add a thumbnail_url column, and update all schema relations and queries
- Extend inquiry and upload endpoints to return and accept thumbnail URLs and filekeys
- Update folder paths and URL builders to separate thumbnail storage
- Modify client and server upload strategies and services to include thumbnailUrl and combined size in records and responses
- Update UI components and storage composables to display thumbnails instead of full images

Build:
- Add sharp and picsquish dependencies for thumbnail processing