### PR TITLE
feat: allow video upload and empty thumbnail in such case

### DIFF
--- a/app/components/event/EventUploadedPictureList.client.vue
+++ b/app/components/event/EventUploadedPictureList.client.vue
@@ -65,14 +65,26 @@ async function handleDelete() {
             class="relative aspect-square cursor-pointer group appearance-none border-0 rounded-none bg-none"
             type="button" @click="toggleSelection(picture.deleteId)"
           >
-            <img
-              :src="picture.thumbnailUrl" alt=""
-              class="w-full h-full object-cover transition-all duration-200 relative" :class="{
-                'ring-4 ring-merino-400 ring-opacity-70 z-10': selectedPictures.has(picture.deleteId),
-                'group-hover:opacity-90': !selectedPictures.has(picture.deleteId),
-                'animate-pulse': selectedPictures.has(picture.deleteId) && isDeleting,
-              }" loading="lazy"
-            >
+            <template v-if="picture.isVideo === false && picture.thumbnailUrl">
+              <img
+                :src="picture.thumbnailUrl" alt=""
+                class="w-full h-full object-cover transition-all duration-200 relative" :class="{
+                  'ring-4 ring-merino-400 ring-opacity-70 z-10': selectedPictures.has(picture.deleteId),
+                  'group-hover:opacity-90': !selectedPictures.has(picture.deleteId),
+                  'animate-pulse': selectedPictures.has(picture.deleteId) && isDeleting,
+                }" loading="lazy"
+              >
+            </template>
+            <template v-else-if="picture.isVideo">
+              <video
+                :src="picture.url" class="w-full h-full object-cover transition-all duration-200 relative" :class="{
+                  'ring-4 ring-merino-400 ring-opacity-70 z-10': selectedPictures.has(picture.deleteId),
+                  'group-hover:opacity-90': !selectedPictures.has(picture.deleteId),
+                  'animate-pulse': selectedPictures.has(picture.deleteId) && isDeleting,
+                }" muted playsinline preload="metadata"
+              />
+              <span class="absolute bottom-2 right-2 left-2 text-center text-white text-shadow-neutral-500 text-shadow-md tracking-wider z-10">video</span>
+            </template>
             <div
               v-if="isSelectionMode"
               class="absolute z-20 top-2 right-2 w-6 h-6 rounded-full border-2 border-white shadow-lg flex items-center justify-center transition-all duration-200"

--- a/app/components/event/picture/EventPictureThumbnail.client.vue
+++ b/app/components/event/picture/EventPictureThumbnail.client.vue
@@ -71,13 +71,25 @@ function handleTouchEnd() {
 
 <template>
   <div class="relative overflow-hidden select-none">
-    <button class="appearance-none border-0 rounded-none bg-none w-full h-full block" @touchstart="handleTouchStart" @click="handleTouchEnd" @mousedown="handleTouchStart" @contextmenu.prevent>
-      <img
-        ref="imageRef" :src="picture.thumbnailUrl" class="w-full aspect-square object-cover pointer-events-none" :class="[
-          isLoaded ? 'scale-100 opacity-100' : 'scale-105 opacity-0',
-          shouldAnimate ? 'transition-all duration-700' : '',
-        ]" :data-loaded="isLoaded" @load="handleImageLoad"
-      >
+    <button class="appearance-none border-0 rounded-none bg-none w-full h-full block relative" @touchstart="handleTouchStart" @click="handleTouchEnd" @mousedown="handleTouchStart" @contextmenu.prevent>
+      <template v-if="picture.mediaType === 'picture'">
+        <img
+          ref="imageRef" :src="picture.thumbnailUrl" class="w-full h-full aspect-square object-cover pointer-events-none" :class="[
+            isLoaded ? 'scale-100 opacity-100' : 'scale-105 opacity-0',
+            shouldAnimate ? 'transition-all duration-700' : '',
+          ]" :data-loaded="isLoaded" @load="handleImageLoad"
+        >
+      </template>
+      <template v-else-if="picture.mediaType === 'video'">
+        <video class="w-full aspect-square object-cover pointer-events-none bg-almond-500/5" :data-loaded="isLoaded" muted playsinline preload="metadata" @loadeddata="handleImageLoad">
+          <source :src="picture.url" type="video/mp4">
+          Your browser does not support this video.
+        </video>
+
+        <div class="absolute inset-0 flex items-center justify-center bg-black/20">
+          <svg xmlns="http://www.w3.org/2000/svg" class="text-white drop-shadow-2xl drop-shadow-white size-12" width="32" height="32" viewBox="0 0 24 24"><!-- Icon from Material Symbols by Google - https://github.com/google/material-design-icons/blob/master/LICENSE --><path fill="currentColor" d="M8 17.175V6.825q0-.425.3-.713t.7-.287q.125 0 .263.037t.262.113l8.15 5.175q.225.15.338.375t.112.475t-.112.475t-.338.375l-8.15 5.175q-.125.075-.262.113T9 18.175q-.4 0-.7-.288t-.3-.712" /></svg>
+        </div>
+      </template>
     </button>
     <ClientOnly>
       <button

--- a/app/components/event/picture/insta-view/EventPictureInstaViewThumbnail.client.vue
+++ b/app/components/event/picture/insta-view/EventPictureInstaViewThumbnail.client.vue
@@ -11,6 +11,8 @@ const { picture } = defineProps<{
 }>()
 
 const { isInFavorite, toggleFavorite } = useFavoriteStorage()
+const video = useTemplateRef('video')
+const isVideoVisible = useElementVisibility(video)
 
 async function downloadPicture() {
   try {
@@ -59,6 +61,20 @@ function triggerHeartAnimation() {
     showHeartAnimation.value = false
   }, 800) // Animation duration
 }
+
+watch(isVideoVisible, () => {
+  if (!video.value)
+    return
+
+  if (isVideoVisible.value) {
+    video.value.play().catch((error) => {
+      console.error('Error playing video:', error)
+    })
+  }
+  else {
+    video.value.pause()
+  }
+})
 </script>
 
 <template>
@@ -71,7 +87,15 @@ function triggerHeartAnimation() {
       <div v-if="allowDoubleTap && showHeartAnimation" class="absolute z-10 inset-0 w-full h-full flex items-center justify-center pointer-events-none">
         <svg class="size-[20svh] stroke-1 stroke-almond-300 text-almond-300 animate-heart-like" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><!-- Icon from Google Material Icons by Material Design Authors - https://github.com/material-icons/material-icons/blob/master/LICENSE --><path fill="currentColor" d="m12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5C2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3C19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54z" /></svg>
       </div>
-      <img :src="picture.thumbnailUrl" alt="" class="w-full h-auto object-contain max-h-[60svh] bg-almond-500/5" @click="allowDoubleTap ? onImageClick() : undefined">
+      <template v-if="picture.mediaType === 'picture'">
+        <img :src="picture.thumbnailUrl" alt="" class="w-full h-auto object-contain max-h-[60svh] bg-almond-500/5" @click="allowDoubleTap ? onImageClick() : undefined">
+      </template>
+      <template v-else-if="picture.mediaType === 'video'">
+        <video ref="video" class="w-full h-auto object-contain max-h-[60svh] bg-almond-500/5" controls loop muted playsinline controlslist="noremoteplayback" disablepictureinpicture preload="metadata">
+          <source :src="picture.url" type="video/mp4">
+          Your browser does not support this video.
+        </video>
+      </template>
     </div>
     <div class="flex gap-2 px-2 items-baseline mt-1">
       <button class="group transition-transform active:scale-95" :aria-pressed="isInFavorite(picture.id)" type="button" @click="toggleFavorite(picture.id)">

--- a/app/composables/useUploadedPictureStorage.ts
+++ b/app/composables/useUploadedPictureStorage.ts
@@ -1,20 +1,14 @@
+import type { UploadResult } from '~/services/UploadStrategyService'
 import { useStorage } from '@vueuse/core'
-
-export interface UploadedPicture {
-  id: string
-  url: string
-  thumbnailUrl: string
-  deleteId: string
-}
 
 export function useUploadedPictureStorage() {
   const route = useRoute()
   const uuid = computed(() => route.params.uuid as string)
   const storageKey = computed(() => `uploadedPictures_${uuid.value}`)
 
-  const uploadedPictures = useStorage<UploadedPicture[]>(storageKey, [])
+  const uploadedPictures = useStorage<UploadResult[]>(storageKey, [])
 
-  function addUploadedPictures(newPictures: UploadedPicture[]) {
+  function addUploadedPictures(newPictures: UploadResult[]) {
     uploadedPictures.value.push(...newPictures)
   }
 
@@ -28,7 +22,7 @@ export function useUploadedPictureStorage() {
     uploadedPictures.value = []
   }
 
-  function getUploadedPictureByDeleteId(deleteId: string): UploadedPicture | undefined {
+  function getUploadedPictureByDeleteId(deleteId: string): UploadResult | undefined {
     return uploadedPictures.value.find(picture => picture.deleteId === deleteId)
   }
 

--- a/app/services/FileProcessorService.ts
+++ b/app/services/FileProcessorService.ts
@@ -32,6 +32,12 @@ export class FileProcessorService {
    */
   static async extractExifData(file: ClientFile) {
     try {
+      if (file.type && !file.type.startsWith('image/')) {
+        return {
+          capturedAt: new Date(file.lastModified), // Fallback to last modified date for non-image files. Extracting EXIF from videos is not supported.
+        }
+      }
+
       const tags = await ExifReader.load(file.content as string)
 
       let capturedAt = new Date()

--- a/server/api/events/single/[id]/inquire-upload.post.ts
+++ b/server/api/events/single/[id]/inquire-upload.post.ts
@@ -3,7 +3,7 @@ import { inArray } from 'drizzle-orm'
 import z from 'zod'
 import { useDrizzle } from '~~/server/database'
 import { getEventById } from '~~/server/service/EventService'
-import { buildR2UploadedPictureUrl, buildR2UploadedThumbnailUrl } from '~~/server/service/ImageService'
+import { buildR2UploadedPictureUrl, buildR2UploadedThumbnailUrl, isMediaVideoContent } from '~~/server/service/ImageService'
 import { getPresignedUploadUrl } from '~~/server/service/R2Service'
 
 const eventIdRouterParam = z.object({
@@ -100,7 +100,7 @@ export default defineEventHandler(async (event) => {
 
     const filename = `${pictureId}.${fileInformation.extension}`
     const filekey = buildR2UploadedPictureUrl(eventId, filename)
-    const isVideoUpload = fileInformation.contentType.startsWith('video/')
+    const isVideoUpload = isMediaVideoContent(fileInformation.contentType)
     const thumbnailFilekey = isVideoUpload ? null : buildR2UploadedThumbnailUrl(eventId, `${pictureId}.jpeg`)
 
     // For videos, we might not have a thumbnail

--- a/server/api/events/single/[id]/pictures/batch.get.ts
+++ b/server/api/events/single/[id]/pictures/batch.get.ts
@@ -45,6 +45,7 @@ export default defineEventHandler(async (event) => {
       guestId: medias.guestId,
       guestNickname: guests.nickname,
       thumbnailUrl: medias.thumbnailUrl,
+      mediaType: medias.mediaType,
     })
     .from(medias)
     .leftJoin(guests, eq(medias.guestId, guests.id))

--- a/server/api/events/single/[id]/pictures/index.get.ts
+++ b/server/api/events/single/[id]/pictures/index.get.ts
@@ -1,3 +1,4 @@
+import type { mediaType, MediaType } from '~~/server/database/schema/media-schema'
 import { asc, desc, eq, sql } from 'drizzle-orm'
 import z from 'zod'
 import { useDrizzle } from '~~/server/database'
@@ -24,6 +25,7 @@ export interface UploadedPicture {
   createdAt: Date
   guestId: string
   guestNickname: string | null
+  mediaType: MediaType
 }
 
 export default defineEventHandler(async (event) => {
@@ -64,6 +66,7 @@ export default defineEventHandler(async (event) => {
       guestId: medias.guestId,
       guestNickname: guests.nickname,
       thumbnailUrl: medias.thumbnailUrl,
+      mediaType: medias.mediaType,
     })
     .from(medias)
     .leftJoin(guests, eq(medias.guestId, guests.id))

--- a/server/api/events/single/[id]/pictures/index.get.ts
+++ b/server/api/events/single/[id]/pictures/index.get.ts
@@ -20,7 +20,7 @@ const querySchema = z.object({
 export interface UploadedPicture {
   id: string
   url: string
-  thumbnailUrl: string
+  thumbnailUrl: string | null
   capturedAt: Date
   createdAt: Date
   guestId: string

--- a/server/api/events/single/[id]/upload.post.ts
+++ b/server/api/events/single/[id]/upload.post.ts
@@ -1,4 +1,5 @@
 import type { ServerFile } from 'nuxt-file-storage'
+import type { ProcessedFileInfo } from '~~/server/service/upload/UploadStrategy'
 import type { UploadResult } from '~/services/UploadStrategyService'
 import z from 'zod'
 import { getEventById } from '~~/server/service/EventService'
@@ -16,7 +17,7 @@ const fileInformationsSchema = z.array(z.union([
     id: z.uuid(),
     filename: z.string().max(64),
     filekey: z.string().max(256),
-    thumbnailFilekey: z.string().max(256),
+    thumbnailFilekey: z.string().max(256).nullable(),
     hash: z.string().length(64),
     capturedAt: z.coerce.date().optional(),
   }),
@@ -49,7 +50,7 @@ export default defineEventHandler<Promise<UploadResult[]>>(async (event) => {
     })
   }
 
-  let processedFiles
+  let processedFiles: ProcessedFileInfo[]
 
   if (weddingEvent.bucketType === 'filesystem' && files) {
     // This only happens when user uploads files directly.
@@ -77,7 +78,7 @@ export default defineEventHandler<Promise<UploadResult[]>>(async (event) => {
       id: string
       filename: string
       filekey: string
-      thumbnailFilekey: string
+      thumbnailFilekey: string | null
       hash: string
       capturedAt?: Date
     } =>

--- a/server/database/schema/event-schema.ts
+++ b/server/database/schema/event-schema.ts
@@ -19,7 +19,7 @@ export const events = pgTable('events', {
   closeDate: timestamp('close_date').notNull(), // When the event should be closed and all pictures removed
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
-  bucketType: eventBucketType('bucket_type').notNull().default('R2').notNull(),
+  bucketType: eventBucketType('bucket_type').default('R2').notNull(),
   bucketUri: varchar('bucket_uri', { length: 2048 }).notNull(),
 })
 

--- a/server/database/schema/media-schema.ts
+++ b/server/database/schema/media-schema.ts
@@ -1,13 +1,16 @@
 import type { SQL } from 'drizzle-orm'
 import { relations, sql } from 'drizzle-orm'
-import { bigint, pgTable, text, timestamp, uuid, varchar } from 'drizzle-orm/pg-core'
+import { bigint, pgEnum, pgTable, text, timestamp, uuid, varchar } from 'drizzle-orm/pg-core'
 import { events } from './event-schema'
 import { guests } from './guest-schema'
+
+export const mediaType = pgEnum('media_type', ['video', 'picture'])
+export type MediaType = typeof mediaType.enumValues[number]
 
 export const medias = pgTable('medias', {
   id: uuid('id').primaryKey().defaultRandom(),
   url: text('url').notNull(),
-  thumbnailUrl: text('thumbnail_url').notNull(),
+  thumbnailUrl: text('thumbnail_url'),
   filename: varchar('filename', { length: 64 }).notNull().unique(), // Technically could be 32 characters + extension length
   size: bigint('size', { mode: 'number' }).notNull(),
   capturedAt: timestamp('captured_at').defaultNow().notNull(),
@@ -16,7 +19,7 @@ export const medias = pgTable('medias', {
   guestId: uuid('guest_id').notNull().references(() => guests.id, { onDelete: 'cascade' }),
   eventId: uuid('event_id').notNull().references(() => events.id, { onDelete: 'cascade' }),
   pictureHash: varchar('picture_hash', { length: 64 }).notNull(),
-
+  mediaType: mediaType('media_type').default('picture').notNull(),
   generatedUniquePictureHash: text('generated_unique_picture_hash')
     .generatedAlwaysAs((): SQL => sql`${medias.eventId} || ${medias.pictureHash}`)
     .unique(),

--- a/server/service/ImageService.ts
+++ b/server/service/ImageService.ts
@@ -21,10 +21,18 @@ export function getUploadedThumbnailFolder(eventId: string) {
   return `public/events/${eventId}/thumbnails/`
 }
 
-export function buildUploadedPictureUrl(eventId: string, filename: string) {
+export function buildR2UploadedPictureUrl(eventId: string, filename: string) {
   return `events/${eventId}/medias/${filename}`
 }
 
-export function buildUploadedThumbnailUrl(eventId: string, filename: string) {
+export function buildFilesystemUploadedPictureUrl(eventId: string, filename: string) {
+  return `/events/${eventId}/medias/${filename}`
+}
+
+export function buildR2UploadedThumbnailUrl(eventId: string, filename: string) {
   return `events/${eventId}/thumbnails/${filename}`
+}
+
+export function buildFilesystemUploadedThumbnailUrl(eventId: string, filename: string) {
+  return `/events/${eventId}/thumbnails/${filename}`
 }

--- a/server/service/ImageService.ts
+++ b/server/service/ImageService.ts
@@ -36,3 +36,7 @@ export function buildR2UploadedThumbnailUrl(eventId: string, filename: string) {
 export function buildFilesystemUploadedThumbnailUrl(eventId: string, filename: string) {
   return `/events/${eventId}/thumbnails/${filename}`
 }
+
+export function isMediaVideoContent(contentType: string) {
+  return contentType.startsWith('video/')
+}

--- a/server/service/upload/FilesystemUploadStrategy.ts
+++ b/server/service/upload/FilesystemUploadStrategy.ts
@@ -7,7 +7,7 @@ import path from 'node:path'
 import sharp from 'sharp'
 import { useDrizzle } from '~~/server/database'
 import { medias } from '~~/server/database/schema/media-schema'
-import { buildFilesystemUploadedPictureUrl, buildFilesystemUploadedThumbnailUrl, getUploadedPictureFolder, getUploadedThumbnailFolder } from '~~/server/service/ImageService'
+import { buildFilesystemUploadedPictureUrl, buildFilesystemUploadedThumbnailUrl, getUploadedPictureFolder, getUploadedThumbnailFolder, isMediaVideoContent } from '~~/server/service/ImageService'
 import { THUMBNAIL_PROPERTY } from '~~/shared/utils/constants'
 
 export class FilesystemUploadStrategy implements UploadStrategy {
@@ -46,7 +46,7 @@ export class FilesystemUploadStrategy implements UploadStrategy {
           fileInfo.file as ServerFile,
         )
 
-        const isVideo = (fileInfo.contentType || '').startsWith('video/')
+        const isVideo = isMediaVideoContent(fileInfo.contentType)
 
         let thumbnailUrl: string | null = null
         let thumbnailSize = 0

--- a/server/service/upload/FilesystemUploadStrategy.ts
+++ b/server/service/upload/FilesystemUploadStrategy.ts
@@ -56,7 +56,6 @@ export class FilesystemUploadStrategy implements UploadStrategy {
             eventId,
             mediaId,
             fileInfo.file as ServerFile,
-            isVideo,
           )
           thumbnailUrl = thumbnailResult.url
           thumbnailSize = thumbnailResult.size
@@ -120,11 +119,7 @@ export class FilesystemUploadStrategy implements UploadStrategy {
     }
   }
 
-  private async generateAndSaveThumbnail(eventId: string, pictureId: string, file: ServerFile, isVideo: boolean) {
-    if (isVideo) {
-      return { url: 'TODO', size: 0 } // TODO
-    }
-
+  private async generateAndSaveThumbnail(eventId: string, pictureId: string, file: ServerFile) {
     const folderUrl = getUploadedThumbnailFolder(eventId)
     const filename = `${pictureId}.avif`
 

--- a/server/service/upload/PictureUploadOrchestrator.ts
+++ b/server/service/upload/PictureUploadOrchestrator.ts
@@ -46,7 +46,7 @@ export class PictureUploadOrchestrator {
       return {
         hash: fileInfo.hash,
         extension: this.getFileExtension(file.name || ''),
-        contentType: file.type || 'application/octet-stream',
+        contentType: file.type || 'unknown',
         length: Number(file.size),
         capturedAt: fileInfo.capturedAt,
         file,
@@ -64,7 +64,7 @@ export class PictureUploadOrchestrator {
       filename: string
       filekey: string
       capturedAt?: Date
-      thumbnailFilekey: string
+      thumbnailFilekey: string | null
     }>,
   ): R2ProcessedFileInfo[] {
     return fileInformations.map(info => ({
@@ -76,7 +76,7 @@ export class PictureUploadOrchestrator {
       id: info.id,
       filename: info.filename,
       filekey: info.filekey,
-      file: info.filekey,
+      file: undefined,
       thumbnailFilekey: info.thumbnailFilekey,
     }))
   }

--- a/server/service/upload/PictureUploadOrchestrator.ts
+++ b/server/service/upload/PictureUploadOrchestrator.ts
@@ -46,7 +46,7 @@ export class PictureUploadOrchestrator {
       return {
         hash: fileInfo.hash,
         extension: this.getFileExtension(file.name || ''),
-        contentType: file.type || 'unknown',
+        contentType: file.type || 'application/octet-stream',
         length: Number(file.size),
         capturedAt: fileInfo.capturedAt,
         file,
@@ -76,7 +76,6 @@ export class PictureUploadOrchestrator {
       id: info.id,
       filename: info.filename,
       filekey: info.filekey,
-      file: undefined,
       thumbnailFilekey: info.thumbnailFilekey,
     }))
   }

--- a/server/service/upload/R2UploadStrategy.ts
+++ b/server/service/upload/R2UploadStrategy.ts
@@ -4,6 +4,7 @@ import crypto from 'node:crypto'
 import { useDrizzle } from '~~/server/database'
 import { medias } from '~~/server/database/schema/media-schema'
 import { buildPublicUrl, retrieveFileMetadata } from '~~/server/service/R2Service'
+import { isMediaVideoContent } from '../ImageService'
 
 export class R2UploadStrategy implements UploadStrategy {
   requiresPresignedUrls = (): boolean => true
@@ -28,7 +29,7 @@ export class R2UploadStrategy implements UploadStrategy {
     for (const fileInfo of files) {
       try {
         const uploadResult = await this.verifyPictureWasUploaded(fileInfo, eventId, guestId)
-        const isVideo = fileInfo.contentType.startsWith('video/')
+        const isVideo = isMediaVideoContent(fileInfo.contentType)
 
         if (!uploadResult.success) {
           throw createError({
@@ -126,7 +127,7 @@ export class R2UploadStrategy implements UploadStrategy {
         actualSize: Number((fileMetadata.ContentLength ?? 0) + (thumbnailMetadata?.ContentLength ?? 0)),
         url: buildPublicUrl(fileInfo.filekey),
         thumbnailUrl: fileInfo.thumbnailFilekey ? buildPublicUrl(fileInfo.thumbnailFilekey) : null,
-        isVideo: fileInfo.thumbnailFilekey === null,
+        isVideo: fileMetadata.ContentType && isMediaVideoContent(fileMetadata.ContentType),
       }
     }
     else {

--- a/server/service/upload/R2UploadStrategy.ts
+++ b/server/service/upload/R2UploadStrategy.ts
@@ -28,6 +28,7 @@ export class R2UploadStrategy implements UploadStrategy {
     for (const fileInfo of files) {
       try {
         const uploadResult = await this.verifyPictureWasUploaded(fileInfo, eventId, guestId)
+        const isVideo = fileInfo.contentType.startsWith('video/')
 
         if (!uploadResult.success) {
           throw createError({
@@ -59,7 +60,8 @@ export class R2UploadStrategy implements UploadStrategy {
           pictureHash: fileInfo.hash,
           size: uploadResult.actualSize,
           magicDeleteId,
-          thumbnailUrl: uploadResult.thumbnailUrl,
+          thumbnailUrl: uploadResult.thumbnailUrl ?? null,
+          mediaType: isVideo ? 'video' : 'picture',
         })
 
         results.push({
@@ -67,6 +69,7 @@ export class R2UploadStrategy implements UploadStrategy {
           url: uploadResult.url,
           thumbnailUrl: uploadResult.thumbnailUrl,
           deleteId: magicDeleteId,
+          isVideo,
         })
       }
       catch (error) {
@@ -98,12 +101,12 @@ export class R2UploadStrategy implements UploadStrategy {
       })
     }
 
-    const [fileMetadata, thumbnailMetadata] = await Promise.all([retrieveFileMetadata(fileInfo.filekey), retrieveFileMetadata(fileInfo.thumbnailFilekey)])
+    const [fileMetadata, thumbnailMetadata] = await Promise.all([retrieveFileMetadata(fileInfo.filekey), fileInfo.thumbnailFilekey ? retrieveFileMetadata(fileInfo.thumbnailFilekey) : Promise.resolve(null)])
     if ((fileMetadata.Metadata && 'eventid' in fileMetadata.Metadata && 'guestid' in fileMetadata.Metadata)
-      && (thumbnailMetadata.Metadata && 'eventid' in thumbnailMetadata.Metadata && 'guestid' in thumbnailMetadata.Metadata)
+      && (thumbnailMetadata === null || (thumbnailMetadata !== null && thumbnailMetadata.Metadata && 'eventid' in thumbnailMetadata.Metadata && 'guestid' in thumbnailMetadata.Metadata))
     ) {
       if (fileMetadata.Metadata.eventid !== eventId || fileMetadata.Metadata.guestid !== guestId
-        || thumbnailMetadata.Metadata.eventid !== eventId || thumbnailMetadata.Metadata.guestid !== guestId) {
+        || (thumbnailMetadata !== null && (thumbnailMetadata.Metadata?.eventid !== eventId || thumbnailMetadata.Metadata?.guestid !== guestId))) {
         throw createError({
           statusCode: 400,
           statusMessage: 'File metadata does not match event or guest',
@@ -112,17 +115,18 @@ export class R2UploadStrategy implements UploadStrategy {
             expectedGuestId: guestId,
             actualEventId: fileMetadata.Metadata.eventid,
             actualGuestId: fileMetadata.Metadata.guestid,
-            actualThumbnailEventId: thumbnailMetadata.Metadata.eventid,
-            actualThumbnailGuestId: thumbnailMetadata.Metadata.guestid,
+            actualThumbnailEventId: thumbnailMetadata?.Metadata?.eventid,
+            actualThumbnailGuestId: thumbnailMetadata?.Metadata?.guestid,
           },
         })
       }
 
       return {
         success: true,
-        actualSize: Number((fileMetadata.ContentLength ?? 0) + (thumbnailMetadata.ContentLength ?? 0)),
+        actualSize: Number((fileMetadata.ContentLength ?? 0) + (thumbnailMetadata?.ContentLength ?? 0)),
         url: buildPublicUrl(fileInfo.filekey),
-        thumbnailUrl: buildPublicUrl(fileInfo.thumbnailFilekey),
+        thumbnailUrl: fileInfo.thumbnailFilekey ? buildPublicUrl(fileInfo.thumbnailFilekey) : null,
+        isVideo: fileInfo.thumbnailFilekey === null,
       }
     }
     else {

--- a/server/service/upload/UploadStrategy.ts
+++ b/server/service/upload/UploadStrategy.ts
@@ -14,14 +14,15 @@ export interface R2ProcessedFileInfo extends ProcessedFileInfo {
   id: string
   filename: string
   filekey: string
-  thumbnailFilekey: string
+  thumbnailFilekey: string | null
 }
 
 export interface UploadResult {
   id: string
   url: string
-  thumbnailUrl: string
+  thumbnailUrl: string | null
   deleteId: string
+  isVideo: boolean
 }
 
 export interface UploadStrategy {


### PR DESCRIPTION
## Summary by Sourcery

Add support for video uploads by distinguishing media type, skipping thumbnail generation for videos, and rendering video previews in the UI

New Features:
- Allow uploading videos alongside images and tag them with a mediaType flag

Enhancements:
- Introduce mediaType enum and optional thumbnailUrl in the database schema
- Update Filesystem and R2 upload strategies to detect videos, skip thumbnail creation, mark isVideo, and use dedicated URL builders
- Revise R2 presigned URL inquiry and metadata checks to accept null thumbnail keys for videos
- Enhance front-end components to render video elements with play indicators and auto-play/pause on visibility
- Fallback to file.lastModified date when extracting EXIF data for non-image files